### PR TITLE
Correct console formatting

### DIFF
--- a/Docker/simple-nodejs/app.js
+++ b/Docker/simple-nodejs/app.js
@@ -16,6 +16,4 @@ app.get('/', (req, res) => {
 });
 
 app.listen(PORT, HOST);
-console.log("Running on http://${HOST}:${PORT}");
-
-
+console.log("Running on http://%s:%d", HOST, PORT);


### PR DESCRIPTION
Use string format commands to print out the host and port variables